### PR TITLE
Use '#pragma once' instead of '#ifndef' guards

### DIFF
--- a/src/env.hpp
+++ b/src/env.hpp
@@ -1,5 +1,4 @@
-#ifndef ENV
-#define ENV
+#pragma once
 
 #include "heap.hpp"
 #include "stack.hpp"
@@ -16,5 +15,3 @@ struct Env {
 
   ~Env();
 };
-
-#endif

--- a/src/heap.hpp
+++ b/src/heap.hpp
@@ -1,5 +1,4 @@
-#ifndef HEAP
-#define HEAP
+#pragma once
 
 #include <string>
 #include <unordered_map>
@@ -29,5 +28,3 @@ struct Heap {
 
 	~Heap();
 };
-
-#endif

--- a/src/heapobject.hpp
+++ b/src/heapobject.hpp
@@ -1,5 +1,4 @@
-#ifndef HEAP_OBJECT
-#define HEAP_OBJECT
+#pragma once
 
 #include <sstream>
 #include <iostream>
@@ -17,7 +16,7 @@ enum class Type : id_type {
 	BOOLEAN,
 	MAP,
 	ARRAY,
-	SSCOPE //SCOPE doesn't work, is probably predefinded somewhere
+	SCOPE //SCOPE doesn't work, is probably predefinded somewhere
 };
 
 /**
@@ -160,5 +159,3 @@ struct CodeFunction : Function {
 	std::vector<Line> lines;
 
 };
-
-#endif

--- a/src/scope.cpp
+++ b/src/scope.cpp
@@ -1,11 +1,11 @@
 #include "scope.hpp"
 #include "heap.hpp"
 
-/*Scope::Scope(Heap *heap) : HeapObject(Type::SSCOPE, heap) {
+/*Scope::Scope(Heap *heap) : HeapObject(Type::SCOPE, heap) {
     isRoot = true;
 }*/
 
-Scope::Scope(Heap *heap, Scope *scope) : HeapObject(Type::SSCOPE, heap) {
+Scope::Scope(Heap *heap, Scope *scope) : HeapObject(Type::SCOPE, heap) {
     parent = scope;
     if (scope == 0){
         isRoot = true;

--- a/src/scope.hpp
+++ b/src/scope.hpp
@@ -1,5 +1,4 @@
-#ifndef SCOPE
-#define SCOPE
+#pragma once
 
 #include <map>
 
@@ -36,5 +35,3 @@ struct Scope : HeapObject {
 
     std::string str_large();
 };
-
-#endif

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -1,5 +1,4 @@
-#ifndef UTILS
-#define UTILS
+#pragma once
 
 #include <iostream>
 #include <sstream>
@@ -10,5 +9,3 @@
 typedef uint64_t id_type;
 /** Type of the value of an Int object */
 typedef int64_t int_type;
-
-#endif


### PR DESCRIPTION
`#pragma once`, while not part of the C++11 standard, is supported across virtually all compilers, including g++ and clang++.

In this case, the `#ifndef SCOPE` guard in `scope.hpp` was causing a name collision with an enum member `Type::SCOPE`, which was therefore called `SSCOPE`. As this is now unnecessary, it has been renamed to `SCOPE`.
